### PR TITLE
[FEATURE] Add php-ext `pcntl` to the images

### DIFF
--- a/core-testing-php72/Dockerfile
+++ b/core-testing-php72/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     && sync \
     && install-php-extensions \
         ssh2 \
+        pcntl \
     # write version information \
     && touch /etc/typo3-image-info.json \
     && php -r '$gv=explode(" ", `git --version`)[2];$core=[];$exts=[];$pv=phpversion(); foreach (get_loaded_extensions() as $extName) {$extVersion = phpversion($extName); if ($pv === $extVersion) {$core[$extName] = $extVersion;} else {$exts[$extName] = $extVersion;}} ksort($core); ksort($exts); echo \json_encode(["name" => getenv("IMAGE_NAME"), "version" => getenv("IMAGE_VERSION"), "platform" => getenv("TARGETPLATFORM"), "php" => $pv, "xdebug" => phpversion("xdebug"), "git" => $gv, "core" => $core, "pecl" => $exts], JSON_PRETTY_PRINT) . PHP_EOL;' > /etc/typo3-image-info.json \

--- a/core-testing-php73/Dockerfile
+++ b/core-testing-php73/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     && sync \
     && install-php-extensions \
         ssh2 \
+        pcntl \
     # write version information \
     && touch /etc/typo3-image-info.json \
     && php -r '$gv=explode(" ", `git --version`)[2];$core=[];$exts=[];$pv=phpversion(); foreach (get_loaded_extensions() as $extName) {$extVersion = phpversion($extName); if ($pv === $extVersion) {$core[$extName] = $extVersion;} else {$exts[$extName] = $extVersion;}} ksort($core); ksort($exts); echo \json_encode(["name" => getenv("IMAGE_NAME"), "version" => getenv("IMAGE_VERSION"), "platform" => getenv("TARGETPLATFORM"), "php" => $pv, "xdebug" => phpversion("xdebug"), "git" => $gv, "core" => $core, "pecl" => $exts], JSON_PRETTY_PRINT) . PHP_EOL;' > /etc/typo3-image-info.json \

--- a/core-testing-php74/Dockerfile
+++ b/core-testing-php74/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     && sync \
     && install-php-extensions \
         ssh2 \
+        pcntl \
     # write version information \
     && touch /etc/typo3-image-info.json \
     && php -r '$gv=explode(" ", `git --version`)[2];$core=[];$exts=[];$pv=phpversion(); foreach (get_loaded_extensions() as $extName) {$extVersion = phpversion($extName); if ($pv === $extVersion) {$core[$extName] = $extVersion;} else {$exts[$extName] = $extVersion;}} ksort($core); ksort($exts); echo \json_encode(["name" => getenv("IMAGE_NAME"), "version" => getenv("IMAGE_VERSION"), "platform" => getenv("TARGETPLATFORM"), "php" => $pv, "xdebug" => phpversion("xdebug"), "git" => $gv, "core" => $core, "pecl" => $exts], JSON_PRETTY_PRINT) . PHP_EOL;' > /etc/typo3-image-info.json \

--- a/core-testing-php80/Dockerfile
+++ b/core-testing-php80/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     && sync \
     && install-php-extensions \
         ssh2 \
+        pcntl \
     # write version information \
     && touch /etc/typo3-image-info.json \
     && php -r '$gv=explode(" ", `git --version`)[2];$core=[];$exts=[];$pv=phpversion(); foreach (get_loaded_extensions() as $extName) {$extVersion = phpversion($extName); if ($pv === $extVersion) {$core[$extName] = $extVersion;} else {$exts[$extName] = $extVersion;}} ksort($core); ksort($exts); echo \json_encode(["name" => getenv("IMAGE_NAME"), "version" => getenv("IMAGE_VERSION"), "platform" => getenv("TARGETPLATFORM"), "php" => $pv, "xdebug" => phpversion("xdebug"), "git" => $gv, "core" => $core, "pecl" => $exts], JSON_PRETTY_PRINT) . PHP_EOL;' > /etc/typo3-image-info.json \

--- a/core-testing-php81/Dockerfile
+++ b/core-testing-php81/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     && sync \
     && install-php-extensions \
         ssh2 \
+        pcntl \
     # write version information \
     && touch /etc/typo3-image-info.json \
     && php -r '$gv=explode(" ", `git --version`)[2];$core=[];$exts=[];$pv=phpversion(); foreach (get_loaded_extensions() as $extName) {$extVersion = phpversion($extName); if ($pv === $extVersion) {$core[$extName] = $extVersion;} else {$exts[$extName] = $extVersion;}} ksort($core); ksort($exts); echo \json_encode(["name" => getenv("IMAGE_NAME"), "version" => getenv("IMAGE_VERSION"), "platform" => getenv("TARGETPLATFORM"), "php" => $pv, "xdebug" => phpversion("xdebug"), "git" => $gv, "core" => $core, "pecl" => $exts], JSON_PRETTY_PRINT) . PHP_EOL;' > /etc/typo3-image-info.json \

--- a/core-testing-php82/Dockerfile
+++ b/core-testing-php82/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     && sync \
     && install-php-extensions \
         ssh2 \
+        pcntl \
     # write version information \
     && touch /etc/typo3-image-info.json \
     && php -r '$gv=explode(" ", `git --version`)[2];$core=[];$exts=[];$pv=phpversion(); foreach (get_loaded_extensions() as $extName) {$extVersion = phpversion($extName); if ($pv === $extVersion) {$core[$extName] = $extVersion;} else {$exts[$extName] = $extVersion;}} ksort($core); ksort($exts); echo \json_encode(["name" => getenv("IMAGE_NAME"), "version" => getenv("IMAGE_VERSION"), "platform" => getenv("TARGETPLATFORM"), "php" => $pv, "xdebug" => phpversion("xdebug"), "git" => $gv, "core" => $core, "pecl" => $exts], JSON_PRETTY_PRINT) . PHP_EOL;' > /etc/typo3-image-info.json \

--- a/core-testing-php83/Dockerfile
+++ b/core-testing-php83/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     && sync \
     && install-php-extensions \
         ssh2 \
+        pcntl \
     # write version information \
     && touch /etc/typo3-image-info.json \
     && php -r '$gv=explode(" ", `git --version`)[2];$core=[];$exts=[];$pv=phpversion(); foreach (get_loaded_extensions() as $extName) {$extVersion = phpversion($extName); if ($pv === $extVersion) {$core[$extName] = $extVersion;} else {$exts[$extName] = $extVersion;}} ksort($core); ksort($exts); echo \json_encode(["name" => getenv("IMAGE_NAME"), "version" => getenv("IMAGE_VERSION"), "platform" => getenv("TARGETPLATFORM"), "php" => $pv, "xdebug" => phpversion("xdebug"), "git" => $gv, "core" => $core, "pecl" => $exts], JSON_PRETTY_PRINT) . PHP_EOL;' > /etc/typo3-image-info.json \

--- a/images.json
+++ b/images.json
@@ -1,86 +1,86 @@
 {
     "core-testing-php72": {
         "context": "core-testing-php72",
-        "full": "1.0.6",
+        "full": "1.1.0",
         "gh-image-basename": "ghcr.io\/typo3\/core-testing-php72",
         "gh-image-name": "ghcr.io\/sbuerk\/demo-core-testing-php72",
         "lookup-name": "core-testing-php72",
         "major": 1,
-        "minor": 0,
-        "patchlevel": 6,
+        "minor": 1,
+        "patchlevel": 0,
         "platforms": "linux\/amd64,linux\/arm64",
-        "short": "1.0"
+        "short": "1.1"
     },
     "core-testing-php73": {
         "context": "core-testing-php73",
-        "full": "1.0.6",
+        "full": "1.1.0",
         "gh-image-basename": "ghcr.io\/typo3\/core-testing-php73",
         "gh-image-name": "ghcr.io\/sbuerk\/demo-core-testing-php73",
         "lookup-name": "core-testing-php73",
         "major": 1,
-        "minor": 0,
-        "patchlevel": 6,
+        "minor": 1,
+        "patchlevel": 0,
         "platforms": "linux\/amd64,linux\/arm64",
-        "short": "1.0"
+        "short": "1.1"
     },
     "core-testing-php74": {
         "context": "core-testing-php74",
-        "full": "1.0.7",
+        "full": "1.1.0",
         "gh-image-basename": "ghcr.io\/typo3\/core-testing-php74",
         "gh-image-name": "ghcr.io\/sbuerk\/demo-core-testing-php74",
         "lookup-name": "core-testing-php74",
         "major": 1,
-        "minor": 0,
-        "patchlevel": 7,
+        "minor": 1,
+        "patchlevel": 0,
         "platforms": "linux\/amd64,linux\/arm64",
-        "short": "1.0"
+        "short": "1.1"
     },
     "core-testing-php80": {
         "context": "core-testing-php80",
-        "full": "1.0.7",
+        "full": "1.1.0",
         "gh-image-basename": "ghcr.io\/typo3\/core-testing-php80",
         "gh-image-name": "ghcr.io\/sbuerk\/demo-core-testing-php80",
         "lookup-name": "core-testing-php80",
         "major": 1,
-        "minor": 0,
-        "patchlevel": 7,
+        "minor": 1,
+        "patchlevel": 0,
         "platforms": "linux\/amd64,linux\/arm64",
-        "short": "1.0"
+        "short": "1.1"
     },
     "core-testing-php81": {
         "context": "core-testing-php81",
-        "full": "1.0.17",
+        "full": "1.1.0",
         "gh-image-basename": "ghcr.io\/typo3\/core-testing-php81",
         "gh-image-name": "ghcr.io\/sbuerk\/demo-core-testing-php81",
         "lookup-name": "core-testing-php81",
         "major": 1,
-        "minor": 0,
-        "patchlevel": 17,
+        "minor": 1,
+        "patchlevel": 0,
         "platforms": "linux\/amd64,linux\/arm64",
-        "short": "1.0"
+        "short": "1.1"
     },
     "core-testing-php82": {
         "context": "core-testing-php82",
-        "full": "1.0.15",
+        "full": "1.1.0",
         "gh-image-basename": "ghcr.io\/typo3\/core-testing-php82",
         "gh-image-name": "ghcr.io\/sbuerk\/demo-core-testing-php82",
         "lookup-name": "core-testing-php82",
         "major": 1,
-        "minor": 0,
-        "patchlevel": 15,
+        "minor": 1,
+        "patchlevel": 0,
         "platforms": "linux\/amd64,linux\/arm64",
-        "short": "1.0"
+        "short": "1.1"
     },
     "core-testing-php83": {
         "context": "core-testing-php83",
-        "full": "1.0.13",
+        "full": "1.1.0",
         "gh-image-basename": "ghcr.io\/typo3\/core-testing-php83",
         "gh-image-name": "ghcr.io\/sbuerk\/demo-core-testing-php83",
         "lookup-name": "core-testing-php83",
         "major": 1,
-        "minor": 0,
-        "patchlevel": 13,
+        "minor": 1,
+        "patchlevel": 0,
         "platforms": "linux\/amd64,linux\/arm64",
-        "short": "1.0"
+        "short": "1.1"
     }
 }

--- a/templates/Dockerfile-core-testing-phpXY
+++ b/templates/Dockerfile-core-testing-phpXY
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     && sync \
     && install-php-extensions \
         ssh2 \
+        pcntl \
     # write version information \
     && touch /etc/typo3-image-info.json \
     && php -r '$gv=explode(" ", `git --version`)[2];$core=[];$exts=[];$pv=phpversion(); foreach (get_loaded_extensions() as $extName) {$extVersion = phpversion($extName); if ($pv === $extVersion) {$core[$extName] = $extVersion;} else {$exts[$extName] = $extVersion;}} ksort($core); ksort($exts); echo \json_encode(["name" => getenv("IMAGE_NAME"), "version" => getenv("IMAGE_VERSION"), "platform" => getenv("TARGETPLATFORM"), "php" => $pv, "xdebug" => phpversion("xdebug"), "git" => $gv, "core" => $core, "pecl" => $exts], JSON_PRETTY_PRINT) . PHP_EOL;' > /etc/typo3-image-info.json \


### PR DESCRIPTION
One project using these images has now the
requirement for the `pcntl` php extension.

This change adds the additional extension
into all included images and also to the
template.

Raised all image version to the next minor.
